### PR TITLE
chore: scaffold llm responses api prompt contracts

### DIFF
--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -6,3 +6,4 @@ Boundaries:
 
 - Centralize model invocation and response parsing.
 - Keep prompts versioned and testable.
+- Keep provider-side memory disabled (`store=False`) so persisted artifacts remain source of truth.

--- a/packages/llm/src/helm_llm/__init__.py
+++ b/packages/llm/src/helm_llm/__init__.py
@@ -1,1 +1,22 @@
 """OpenAI Responses API wrappers and prompt interfaces."""
+
+from helm_llm.client import LLMClient
+from helm_llm.contracts import (
+    DAILY_DIGEST_CONTRACT,
+    EMAIL_TRIAGE_CONTRACT,
+    STUDY_SUMMARY_CONTRACT,
+    PromptContract,
+)
+from helm_llm.errors import LLMError, LLMRequestError, LLMResponseFormatError, LLMTimeoutError
+
+__all__ = [
+    "LLMClient",
+    "PromptContract",
+    "EMAIL_TRIAGE_CONTRACT",
+    "DAILY_DIGEST_CONTRACT",
+    "STUDY_SUMMARY_CONTRACT",
+    "LLMError",
+    "LLMTimeoutError",
+    "LLMRequestError",
+    "LLMResponseFormatError",
+]

--- a/packages/llm/src/helm_llm/client.py
+++ b/packages/llm/src/helm_llm/client.py
@@ -1,19 +1,80 @@
 import os
+from collections.abc import Mapping
+from typing import Any
 
-from openai import OpenAI
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI
+
+from helm_llm.contracts.base import PromptContract
+from helm_llm.errors import LLMRequestError, LLMResponseFormatError, LLMTimeoutError
 
 
 class LLMClient:
-    def __init__(self) -> None:
-        api_key = os.getenv("OPENAI_API_KEY", "")
-        if not api_key:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        default_model: str | None = None,
+        timeout_seconds: float | None = None,
+        openai_client: Any | None = None,
+    ) -> None:
+        resolved_api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self._default_model = default_model or os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+        self._timeout_seconds = timeout_seconds or float(os.getenv("OPENAI_TIMEOUT_SECONDS", "30"))
+
+        if openai_client is not None:
+            self._client = openai_client
+            return
+
+        if not resolved_api_key:
             raise RuntimeError("OPENAI_API_KEY is required")
-        self._client = OpenAI(api_key=api_key)
+        self._client = OpenAI(api_key=resolved_api_key, timeout=self._timeout_seconds)
 
     def summarize(self, text: str, model: str | None = None) -> str:
-        # TODO(v1-phase2): replace with prompt contracts and structured outputs.
-        response = self._client.responses.create(
-            model=model or os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
-            input=[{"role": "user", "content": f"Summarize this text in 3 bullets:\n{text}"}],
+        response = self._create_response(
+            model=model or self._default_model,
+            instructions="Summarize the input in 3 concise bullets.",
+            input=[{"role": "user", "content": text}],
+            max_output_tokens=500,
         )
         return response.output_text
+
+    def run_contract(
+        self,
+        contract: PromptContract,
+        payload: Mapping[str, Any],
+        *,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        response = self._create_response(
+            model=model or self._default_model,
+            instructions=contract.system_prompt,
+            input=[{"role": "user", "content": contract.render_user_input(payload)}],
+            max_output_tokens=contract.max_output_tokens,
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": contract.contract_id,
+                    "strict": True,
+                    "schema": contract.output_schema,
+                }
+            },
+            metadata={"contract_id": contract.contract_id},
+        )
+
+        if not response.output_text:
+            raise LLMResponseFormatError("model response did not include output_text")
+
+        return contract.parse_output(response.output_text)
+
+    def _create_response(self, **kwargs: Any) -> Any:
+        # Artifact-driven execution: disable provider-side storage/memory for v1.
+        kwargs.setdefault("store", False)
+        kwargs.setdefault("timeout", self._timeout_seconds)
+        try:
+            return self._client.responses.create(**kwargs)
+        except (APITimeoutError, TimeoutError) as exc:
+            raise LLMTimeoutError("model request timed out") from exc
+        except (APIConnectionError, APIStatusError) as exc:
+            raise LLMRequestError("model request failed") from exc
+        except Exception as exc:
+            raise LLMRequestError("unexpected model request failure") from exc

--- a/packages/llm/src/helm_llm/contracts/__init__.py
+++ b/packages/llm/src/helm_llm/contracts/__init__.py
@@ -1,0 +1,14 @@
+from helm_llm.contracts.base import PromptContract
+from helm_llm.contracts.digest import DAILY_DIGEST_CONTRACT, DailyDigestOutput
+from helm_llm.contracts.email import EMAIL_TRIAGE_CONTRACT, EmailTriageOutput
+from helm_llm.contracts.study import STUDY_SUMMARY_CONTRACT, StudySummaryOutput
+
+__all__ = [
+    "PromptContract",
+    "EMAIL_TRIAGE_CONTRACT",
+    "DAILY_DIGEST_CONTRACT",
+    "STUDY_SUMMARY_CONTRACT",
+    "EmailTriageOutput",
+    "DailyDigestOutput",
+    "StudySummaryOutput",
+]

--- a/packages/llm/src/helm_llm/contracts/base.py
+++ b/packages/llm/src/helm_llm/contracts/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from helm_llm.errors import LLMResponseFormatError
+
+
+@dataclass(frozen=True)
+class PromptContract:
+    """Versioned contract that defines prompt instructions and output schema."""
+
+    workflow: str
+    version: str
+    system_prompt: str
+    output_schema: Mapping[str, Any]
+    max_output_tokens: int = 1000
+
+    @property
+    def contract_id(self) -> str:
+        return f"{self.workflow}_{self.version}"
+
+    def render_user_input(self, payload: Mapping[str, Any]) -> str:
+        """Render deterministic JSON payload for prompt input."""
+        return json.dumps(payload, sort_keys=True, ensure_ascii=True)
+
+    def parse_output(self, raw_text: str) -> dict[str, Any]:
+        """Parse structured JSON output from model text response."""
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError as exc:
+            raise LLMResponseFormatError("response is not valid JSON") from exc
+
+        if not isinstance(parsed, dict):
+            raise LLMResponseFormatError("response root must be a JSON object")
+        return parsed

--- a/packages/llm/src/helm_llm/contracts/digest.py
+++ b/packages/llm/src/helm_llm/contracts/digest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+from helm_llm.contracts.base import PromptContract
+
+
+class DailyDigestOutput(TypedDict, total=False):
+    summary: str
+    recommended_actions: list[str]
+    must_do_today: list[str]
+
+
+DAILY_DIGEST_CONTRACT = PromptContract(
+    workflow="daily_digest",
+    version="v1",
+    system_prompt=(
+        "You generate concise daily digests for Telegram delivery. "
+        "Return only JSON matching the schema with practical action language."
+    ),
+    output_schema={
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "summary": {"type": "string"},
+            "recommended_actions": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "must_do_today": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["summary", "recommended_actions", "must_do_today"],
+    },
+)

--- a/packages/llm/src/helm_llm/contracts/email.py
+++ b/packages/llm/src/helm_llm/contracts/email.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+from helm_llm.contracts.base import PromptContract
+
+
+class EmailTriageOutput(TypedDict, total=False):
+    classification: str
+    priority: str
+    thread_summary: str
+    action_item: str
+    draft_reply: str
+    should_create_digest_item: bool
+
+
+EMAIL_TRIAGE_CONTRACT = PromptContract(
+    workflow="email_triage",
+    version="v1",
+    system_prompt=(
+        "You are an internal assistant for email triage. "
+        "Return only JSON that matches the requested schema. "
+        "Prefer concise, actionable fields."
+    ),
+    output_schema={
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "classification": {
+                "type": "string",
+                "enum": ["opportunity", "important", "routine", "noise"],
+            },
+            "priority": {"type": "string", "enum": ["high", "medium", "low"]},
+            "thread_summary": {"type": "string"},
+            "action_item": {"type": "string"},
+            "draft_reply": {"type": "string"},
+            "should_create_digest_item": {"type": "boolean"},
+        },
+        "required": [
+            "classification",
+            "priority",
+            "thread_summary",
+            "action_item",
+            "should_create_digest_item",
+        ],
+    },
+)

--- a/packages/llm/src/helm_llm/contracts/study.py
+++ b/packages/llm/src/helm_llm/contracts/study.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+from helm_llm.contracts.base import PromptContract
+
+
+class StudySummaryOutput(TypedDict, total=False):
+    study_summary: str
+    learning_tasks: list[str]
+    knowledge_gaps: list[str]
+    should_create_digest_item: bool
+
+
+STUDY_SUMMARY_CONTRACT = PromptContract(
+    workflow="study_summary",
+    version="v1",
+    system_prompt=(
+        "You summarize study artifacts for durable tracking. "
+        "Return only JSON matching the schema; avoid speculative detail."
+    ),
+    output_schema={
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "study_summary": {"type": "string"},
+            "learning_tasks": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "knowledge_gaps": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "should_create_digest_item": {"type": "boolean"},
+        },
+        "required": [
+            "study_summary",
+            "learning_tasks",
+            "knowledge_gaps",
+            "should_create_digest_item",
+        ],
+    },
+)

--- a/packages/llm/src/helm_llm/errors.py
+++ b/packages/llm/src/helm_llm/errors.py
@@ -1,0 +1,14 @@
+class LLMError(Exception):
+    """Base error for llm package."""
+
+
+class LLMTimeoutError(LLMError):
+    """Raised when model invocation times out."""
+
+
+class LLMRequestError(LLMError):
+    """Raised when model invocation fails for a non-timeout reason."""
+
+
+class LLMResponseFormatError(LLMError):
+    """Raised when a model response cannot be parsed as the expected structure."""

--- a/tests/unit/llm/test_client.py
+++ b/tests/unit/llm/test_client.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+from helm_llm.client import LLMClient
+from helm_llm.contracts import EMAIL_TRIAGE_CONTRACT
+from helm_llm.errors import LLMRequestError, LLMTimeoutError
+
+
+class _FakeResponse:
+    def __init__(self, output_text: str) -> None:
+        self.output_text = output_text
+
+
+class _FakeResponsesAPI:
+    def __init__(self, *, result=None, error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        if self._error:
+            raise self._error
+        return self._result
+
+
+class _FakeOpenAI:
+    def __init__(self, responses) -> None:
+        self.responses = responses
+
+
+def test_run_contract_uses_responses_json_schema_and_store_false() -> None:
+    result_payload = {
+        "classification": "important",
+        "priority": "high",
+        "thread_summary": "Summary",
+        "action_item": "Action",
+        "should_create_digest_item": False,
+    }
+    fake_responses = _FakeResponsesAPI(result=_FakeResponse(json.dumps(result_payload)))
+    client = LLMClient(openai_client=_FakeOpenAI(fake_responses), timeout_seconds=4)
+
+    parsed = client.run_contract(EMAIL_TRIAGE_CONTRACT, {"message": "Hello"}, model="gpt-test")
+
+    assert parsed["priority"] == "high"
+    assert fake_responses.last_kwargs["store"] is False
+    assert fake_responses.last_kwargs["model"] == "gpt-test"
+    assert fake_responses.last_kwargs["text"]["format"]["type"] == "json_schema"
+    assert fake_responses.last_kwargs["text"]["format"]["name"] == "email_triage_v1"
+
+
+def test_run_contract_wraps_timeout_errors() -> None:
+    fake_responses = _FakeResponsesAPI(error=TimeoutError("timed out"))
+    client = LLMClient(openai_client=_FakeOpenAI(fake_responses))
+
+    with pytest.raises(LLMTimeoutError):
+        client.run_contract(EMAIL_TRIAGE_CONTRACT, {"message": "Hello"})
+
+
+def test_run_contract_wraps_non_timeout_errors() -> None:
+    fake_responses = _FakeResponsesAPI(error=RuntimeError("boom"))
+    client = LLMClient(openai_client=_FakeOpenAI(fake_responses))
+
+    with pytest.raises(LLMRequestError):
+        client.run_contract(EMAIL_TRIAGE_CONTRACT, {"message": "Hello"})

--- a/tests/unit/llm/test_contracts.py
+++ b/tests/unit/llm/test_contracts.py
@@ -1,0 +1,55 @@
+import json
+
+import pytest
+from helm_llm.contracts import (
+    DAILY_DIGEST_CONTRACT,
+    EMAIL_TRIAGE_CONTRACT,
+    STUDY_SUMMARY_CONTRACT,
+)
+from helm_llm.errors import LLMResponseFormatError
+
+
+@pytest.mark.parametrize(
+    ("contract", "expected_workflow"),
+    [
+        (EMAIL_TRIAGE_CONTRACT, "email_triage"),
+        (DAILY_DIGEST_CONTRACT, "daily_digest"),
+        (STUDY_SUMMARY_CONTRACT, "study_summary"),
+    ],
+)
+def test_contract_metadata_shape(contract, expected_workflow: str) -> None:
+    assert contract.workflow == expected_workflow
+    assert contract.version == "v1"
+    assert contract.contract_id == f"{expected_workflow}_v1"
+    assert contract.output_schema["type"] == "object"
+
+
+def test_contract_render_user_input_is_deterministic_json() -> None:
+    payload = {"b": 1, "a": "x"}
+    rendered = EMAIL_TRIAGE_CONTRACT.render_user_input(payload)
+    assert rendered == '{"a": "x", "b": 1}'
+
+
+def test_contract_parse_output_accepts_json_object() -> None:
+    raw = json.dumps(
+        {
+            "classification": "important",
+            "priority": "high",
+            "thread_summary": "Budget and timeline request",
+            "action_item": "Reply with next-call slots",
+            "should_create_digest_item": True,
+        }
+    )
+    parsed = EMAIL_TRIAGE_CONTRACT.parse_output(raw)
+    assert parsed["classification"] == "important"
+    assert parsed["should_create_digest_item"] is True
+
+
+def test_contract_parse_output_rejects_non_json() -> None:
+    with pytest.raises(LLMResponseFormatError):
+        EMAIL_TRIAGE_CONTRACT.parse_output("not-json")
+
+
+def test_contract_parse_output_rejects_non_object_root() -> None:
+    with pytest.raises(LLMResponseFormatError):
+        DAILY_DIGEST_CONTRACT.parse_output('["a", "b"]')


### PR DESCRIPTION
## Summary
- add versioned prompt contract scaffolding for `email`, `digest`, and `study` workflows under `packages/llm/src/helm_llm/contracts`
- add `LLMClient.run_contract(...)` using OpenAI Responses API JSON-schema format with `store=False`
- add explicit LLM error wrappers for timeout/request/response-format failures
- export contract/client/error interfaces from `helm_llm.__init__`
- add unit tests for contract parsing/metadata boundaries and client wrapper behavior

## Validation
- `/Users/ankush/git/helm/.venv/bin/pytest -q tests/unit/llm`
- `/Users/ankush/git/helm/.venv/bin/ruff check packages/llm/src/helm_llm tests/unit/llm`

## Notes
- scaffolding only; prompt complexity intentionally minimal per v1 guidance
- keeps artifact-driven behavior by disabling provider-side response storage by default

## Linked Linear
- N/A
