### PR TITLE
feat: add baseline storage schema and repository contracts

### DIFF
--- a/docs/domain/schema-owner.md
+++ b/docs/domain/schema-owner.md
@@ -4,13 +4,17 @@ Schema source: `docs/internal/helm-v1.md` section 10.
 
 Current state:
 
-- Minimal scaffold model exists in `packages/storage/src/helm_storage/models.py`.
-- Full schema migration is pending.
+- V1 entities from `docs/internal/helm-v1.md` section 10 are defined in
+  `packages/storage/src/helm_storage/models.py`.
+- Baseline Alembic migration exists at
+  `migrations/versions/20260308_0001_rhe12_rhe13_baseline.py`.
+- Repository contracts + SQLAlchemy implementations are available for:
+  - `action_items`
+  - `draft_replies`
+  - `digest_items`
 
 Schema rules:
 
 - Every workflow writes durable artifacts.
 - Workflow transitions should be representable from stored state.
 - New entities require migration + doc update.
-
-TODO(v1-phase1): implement first Alembic migration and lock a baseline ERD.

--- a/migrations/versions/20260308_0001_rhe12_rhe13_baseline.py
+++ b/migrations/versions/20260308_0001_rhe12_rhe13_baseline.py
@@ -1,0 +1,213 @@
+"""RHE-12/RHE-13 baseline V1 schema.
+
+Revision ID: 20260308_0001
+Revises:
+Create Date: 2026-03-08 21:15:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260308_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "contacts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("email", sa.String(length=320), nullable=True),
+        sa.Column("linkedin_url", sa.String(length=512), nullable=True),
+        sa.Column("telegram_handle", sa.String(length=64), nullable=True),
+        sa.Column("company", sa.String(length=255), nullable=True),
+        sa.Column("relationship_type", sa.String(length=64), nullable=True),
+        sa.Column("importance_score", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+        sa.UniqueConstraint("linkedin_url"),
+        sa.UniqueConstraint("telegram_handle"),
+    )
+
+    op.create_table(
+        "action_items",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.String(length=255), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("due_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "draft_replies",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("channel_type", sa.String(length=64), nullable=False),
+        sa.Column("thread_id", sa.String(length=255), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=True),
+        sa.Column("draft_text", sa.Text(), nullable=False),
+        sa.Column("tone", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["contact_id"], ["contacts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "agent_runs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("agent_name", sa.String(length=128), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=True),
+        sa.Column("source_id", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "email_messages",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("provider_message_id", sa.String(length=255), nullable=False),
+        sa.Column("thread_id", sa.String(length=255), nullable=False),
+        sa.Column("from_address", sa.String(length=320), nullable=False),
+        sa.Column("subject", sa.String(length=512), nullable=False),
+        sa.Column("body_text", sa.Text(), nullable=True),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider_message_id"),
+    )
+
+    op.create_table(
+        "email_threads",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("latest_subject", sa.String(length=512), nullable=False),
+        sa.Column("thread_summary", sa.Text(), nullable=True),
+        sa.Column("category", sa.String(length=64), nullable=True),
+        sa.Column("priority_score", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "linkedin_messages",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("provider_message_id", sa.String(length=255), nullable=False),
+        sa.Column("thread_id", sa.String(length=255), nullable=False),
+        sa.Column("sender_name", sa.String(length=255), nullable=False),
+        sa.Column("body_text", sa.Text(), nullable=True),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider_message_id"),
+    )
+
+    op.create_table(
+        "linkedin_threads",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("thread_summary", sa.Text(), nullable=True),
+        sa.Column("category", sa.String(length=64), nullable=True),
+        sa.Column("priority_score", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "opportunities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=True),
+        sa.Column("company", sa.String(length=255), nullable=True),
+        sa.Column("role_title", sa.String(length=255), nullable=True),
+        sa.Column("channel_source", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("priority_score", sa.Integer(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["contact_id"], ["contacts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "study_sessions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=False),
+        sa.Column("raw_text", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "knowledge_gaps",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("topic", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("severity", sa.Integer(), nullable=False),
+        sa.Column("source_session_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["source_session_id"], ["study_sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "learning_tasks",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("due_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("related_gap_id", sa.Integer(), nullable=True),
+        sa.Column("source_session_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["related_gap_id"], ["knowledge_gaps.id"]),
+        sa.ForeignKeyConstraint(["source_session_id"], ["study_sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "digest_items",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("domain", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("related_contact_id", sa.Integer(), nullable=True),
+        sa.Column("related_action_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["related_action_id"], ["action_items.id"]),
+        sa.ForeignKeyConstraint(["related_contact_id"], ["contacts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("digest_items")
+    op.drop_table("learning_tasks")
+    op.drop_table("knowledge_gaps")
+    op.drop_table("study_sessions")
+    op.drop_table("opportunities")
+    op.drop_table("linkedin_threads")
+    op.drop_table("linkedin_messages")
+    op.drop_table("email_threads")
+    op.drop_table("email_messages")
+    op.drop_table("agent_runs")
+    op.drop_table("draft_replies")
+    op.drop_table("action_items")
+    op.drop_table("contacts")

--- a/packages/storage/src/helm_storage/__init__.py
+++ b/packages/storage/src/helm_storage/__init__.py
@@ -1,1 +1,5 @@
 """Storage package: SQLAlchemy models, sessions, repositories."""
+
+from helm_storage import models
+
+__all__ = ["models"]

--- a/packages/storage/src/helm_storage/models.py
+++ b/packages/storage/src/helm_storage/models.py
@@ -1,20 +1,186 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from helm_storage.db import Base
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class ContactORM(Base):
+    __tablename__ = "contacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str | None] = mapped_column(String(255))
+    email: Mapped[str | None] = mapped_column(String(320), unique=True)
+    linkedin_url: Mapped[str | None] = mapped_column(String(512), unique=True)
+    telegram_handle: Mapped[str | None] = mapped_column(String(64), unique=True)
+    company: Mapped[str | None] = mapped_column(String(255))
+    relationship_type: Mapped[str | None] = mapped_column(String(64))
+    importance_score: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
 
 
 class ActionItemORM(Base):
     __tablename__ = "action_items"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source_type: Mapped[str | None] = mapped_column(String(64))
+    source_id: Mapped[str | None] = mapped_column(String(255))
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text())
-    priority: Mapped[int] = mapped_column(Integer, default=3)
-    status: Mapped[str] = mapped_column(String(32), default="open")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+    due_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
 
 
-# TODO(v1-phase1): add the complete entity set from the V1 spec.
+class DraftReplyORM(Base):
+    __tablename__ = "draft_replies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    channel_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    thread_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    contact_id: Mapped[int | None] = mapped_column(ForeignKey("contacts.id"))
+    draft_text: Mapped[str] = mapped_column(Text(), nullable=False)
+    tone: Mapped[str | None] = mapped_column(String(64))
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
+class DigestItemORM(Base):
+    __tablename__ = "digest_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    domain: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str] = mapped_column(Text(), nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    related_contact_id: Mapped[int | None] = mapped_column(ForeignKey("contacts.id"))
+    related_action_id: Mapped[int | None] = mapped_column(ForeignKey("action_items.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class AgentRunORM(Base):
+    __tablename__ = "agent_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    agent_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    source_type: Mapped[str | None] = mapped_column(String(64))
+    source_id: Mapped[str | None] = mapped_column(String(255))
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="running")
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error_message: Mapped[str | None] = mapped_column(Text())
+
+
+class EmailMessageORM(Base):
+    __tablename__ = "email_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    provider_message_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    thread_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    from_address: Mapped[str] = mapped_column(String(320), nullable=False)
+    subject: Mapped[str] = mapped_column(String(512), nullable=False)
+    body_text: Mapped[str | None] = mapped_column(Text())
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class EmailThreadORM(Base):
+    __tablename__ = "email_threads"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    latest_subject: Mapped[str] = mapped_column(String(512), nullable=False)
+    thread_summary: Mapped[str | None] = mapped_column(Text())
+    category: Mapped[str | None] = mapped_column(String(64))
+    priority_score: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+
+
+class LinkedInMessageORM(Base):
+    __tablename__ = "linkedin_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    provider_message_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    thread_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    sender_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    body_text: Mapped[str | None] = mapped_column(Text())
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class LinkedInThreadORM(Base):
+    __tablename__ = "linkedin_threads"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    thread_summary: Mapped[str | None] = mapped_column(Text())
+    category: Mapped[str | None] = mapped_column(String(64))
+    priority_score: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+
+
+class OpportunityORM(Base):
+    __tablename__ = "opportunities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    contact_id: Mapped[int | None] = mapped_column(ForeignKey("contacts.id"))
+    company: Mapped[str | None] = mapped_column(String(255))
+    role_title: Mapped[str | None] = mapped_column(String(255))
+    channel_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+    priority_score: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    notes: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
+class StudySessionORM(Base):
+    __tablename__ = "study_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    raw_text: Mapped[str] = mapped_column(Text(), nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class KnowledgeGapORM(Base):
+    __tablename__ = "knowledge_gaps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    topic: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+    severity: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    source_session_id: Mapped[int | None] = mapped_column(ForeignKey("study_sessions.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
+class LearningTaskORM(Base):
+    __tablename__ = "learning_tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+    due_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    related_gap_id: Mapped[int | None] = mapped_column(ForeignKey("knowledge_gaps.id"))
+    source_session_id: Mapped[int | None] = mapped_column(ForeignKey("study_sessions.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/packages/storage/src/helm_storage/repositories/action_items.py
+++ b/packages/storage/src/helm_storage/repositories/action_items.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from helm_storage.models import ActionItemORM
+
+
+@dataclass(slots=True)
+class ActionItemCreate:
+    title: str
+    description: str | None = None
+    priority: int = 3
+    status: str = "open"
+    source_type: str | None = None
+    source_id: str | None = None
+    due_at: datetime | None = None
+
+
+class ActionItemRepository(Protocol):
+    def create(self, payload: ActionItemCreate) -> ActionItemORM: ...
+
+    def list_open(self) -> list[ActionItemORM]: ...
+
+
+class SQLAlchemyActionItemRepository(ActionItemRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, payload: ActionItemCreate) -> ActionItemORM:
+        item = ActionItemORM(
+            title=payload.title,
+            description=payload.description,
+            priority=payload.priority,
+            status=payload.status,
+            source_type=payload.source_type,
+            source_id=payload.source_id,
+            due_at=payload.due_at,
+        )
+        self._session.add(item)
+        self._session.commit()
+        self._session.refresh(item)
+        return item
+
+    def list_open(self) -> list[ActionItemORM]:
+        stmt = (
+            select(ActionItemORM)
+            .where(ActionItemORM.status == "open")
+            .order_by(ActionItemORM.priority.asc(), ActionItemORM.created_at.asc())
+        )
+        return list(self._session.scalars(stmt).all())

--- a/packages/storage/src/helm_storage/repositories/digest_items.py
+++ b/packages/storage/src/helm_storage/repositories/digest_items.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from helm_storage.models import DigestItemORM
+
+
+@dataclass(slots=True)
+class DigestItemCreate:
+    domain: str
+    title: str
+    summary: str
+    priority: int = 3
+    related_contact_id: int | None = None
+    related_action_id: int | None = None
+
+
+class DigestItemRepository(Protocol):
+    def create(self, payload: DigestItemCreate) -> DigestItemORM: ...
+
+    def list_recent(self, limit: int = 10) -> list[DigestItemORM]: ...
+
+
+class SQLAlchemyDigestItemRepository(DigestItemRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, payload: DigestItemCreate) -> DigestItemORM:
+        item = DigestItemORM(
+            domain=payload.domain,
+            title=payload.title,
+            summary=payload.summary,
+            priority=payload.priority,
+            related_contact_id=payload.related_contact_id,
+            related_action_id=payload.related_action_id,
+        )
+        self._session.add(item)
+        self._session.commit()
+        self._session.refresh(item)
+        return item
+
+    def list_recent(self, limit: int = 10) -> list[DigestItemORM]:
+        stmt = select(DigestItemORM).order_by(DigestItemORM.created_at.desc()).limit(limit)
+        return list(self._session.scalars(stmt).all())

--- a/packages/storage/src/helm_storage/repositories/draft_replies.py
+++ b/packages/storage/src/helm_storage/repositories/draft_replies.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from helm_storage.models import DraftReplyORM
+
+
+@dataclass(slots=True)
+class DraftReplyCreate:
+    channel_type: str
+    thread_id: str
+    draft_text: str
+    contact_id: int | None = None
+    tone: str | None = None
+    status: str = "pending"
+
+
+class DraftReplyRepository(Protocol):
+    def create(self, payload: DraftReplyCreate) -> DraftReplyORM: ...
+
+    def list_pending(self) -> list[DraftReplyORM]: ...
+
+    def get_by_id(self, draft_id: int) -> DraftReplyORM | None: ...
+
+    def approve(self, draft_id: int) -> DraftReplyORM | None: ...
+
+    def snooze(self, draft_id: int, *, hours: int = 24) -> DraftReplyORM | None: ...
+
+
+class SQLAlchemyDraftReplyRepository(DraftReplyRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, payload: DraftReplyCreate) -> DraftReplyORM:
+        draft = DraftReplyORM(
+            channel_type=payload.channel_type,
+            thread_id=payload.thread_id,
+            contact_id=payload.contact_id,
+            draft_text=payload.draft_text,
+            tone=payload.tone,
+            status=payload.status,
+        )
+        self._session.add(draft)
+        self._session.commit()
+        self._session.refresh(draft)
+        return draft
+
+    def list_pending(self) -> list[DraftReplyORM]:
+        stmt = (
+            select(DraftReplyORM)
+            .where(DraftReplyORM.status.in_(("pending", "snoozed")))
+            .order_by(DraftReplyORM.created_at.asc())
+        )
+        return list(self._session.scalars(stmt).all())
+
+    def get_by_id(self, draft_id: int) -> DraftReplyORM | None:
+        return self._session.get(DraftReplyORM, draft_id)
+
+    def approve(self, draft_id: int) -> DraftReplyORM | None:
+        draft = self.get_by_id(draft_id)
+        if draft is None:
+            return None
+        draft.status = "approved"
+        self._session.commit()
+        self._session.refresh(draft)
+        return draft
+
+    def snooze(self, draft_id: int, *, hours: int = 24) -> DraftReplyORM | None:
+        draft = self.get_by_id(draft_id)
+        if draft is None:
+            return None
+        draft.status = "snoozed"
+        if hasattr(draft, "updated_at"):
+            draft.updated_at = datetime.now(UTC)
+        self._session.commit()
+        self._session.refresh(draft)
+        return draft

--- a/tests/integration/test_storage_repositories.py
+++ b/tests/integration/test_storage_repositories.py
@@ -1,0 +1,87 @@
+from helm_storage.db import Base
+from helm_storage.repositories.action_items import (
+    ActionItemCreate,
+    SQLAlchemyActionItemRepository,
+)
+from helm_storage.repositories.digest_items import (
+    DigestItemCreate,
+    SQLAlchemyDigestItemRepository,
+)
+from helm_storage.repositories.draft_replies import (
+    DraftReplyCreate,
+    SQLAlchemyDraftReplyRepository,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+
+def make_session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(bind=engine)
+
+
+def test_action_item_repository_happy_path() -> None:
+    session = make_session()
+    repo = SQLAlchemyActionItemRepository(session)
+
+    created = repo.create(
+        ActionItemCreate(
+            title="Reply to recruiter",
+            description="Send availability for interview",
+            priority=1,
+            source_type="email",
+            source_id="msg_123",
+        )
+    )
+
+    open_items = repo.list_open()
+
+    assert created.id is not None
+    assert len(open_items) == 1
+    assert open_items[0].title == "Reply to recruiter"
+    assert open_items[0].source_id == "msg_123"
+
+
+
+def test_draft_reply_repository_happy_path() -> None:
+    session = make_session()
+    repo = SQLAlchemyDraftReplyRepository(session)
+
+    created = repo.create(
+        DraftReplyCreate(
+            channel_type="email",
+            thread_id="thread_42",
+            draft_text="Thanks for reaching out. Happy to discuss next week.",
+            tone="warm",
+        )
+    )
+
+    pending = repo.list_pending()
+
+    assert created.id is not None
+    assert created.status == "pending"
+    assert len(pending) == 1
+    assert pending[0].thread_id == "thread_42"
+
+
+
+def test_digest_item_repository_happy_path() -> None:
+    session = make_session()
+    repo = SQLAlchemyDigestItemRepository(session)
+
+    created = repo.create(
+        DigestItemCreate(
+            domain="opportunity",
+            title="Recruiter follow-up due",
+            summary="A high-priority recruiter thread needs a response today.",
+            priority=1,
+        )
+    )
+
+    recent = repo.list_recent(limit=5)
+
+    assert created.id is not None
+    assert len(recent) == 1
+    assert recent[0].domain == "opportunity"
+    assert recent[0].title == "Recruiter follow-up due"


### PR DESCRIPTION
## Summary
- implement full SQLAlchemy V1 entity set from `docs/internal/helm-v1.md` section 10
- add baseline Alembic migration for the V1 schema (`20260308_0001`)
- add repository contracts + SQLAlchemy implementations for `action_items`, `draft_replies`, and `digest_items`
- add happy-path repository integration tests
- update schema-owner doc with baseline status

## Validation
- `.venv/bin/ruff check packages/storage/src/helm_storage/models.py packages/storage/src/helm_storage/repositories/__init__.py packages/storage/src/helm_storage/repositories/action_items.py packages/storage/src/helm_storage/repositories/draft_replies.py packages/storage/src/helm_storage/repositories/digest_items.py migrations/versions/20260308_0001_rhe12_rhe13_baseline.py tests/integration/test_storage_repositories.py docs/domain/schema-owner.md`
- `.venv/bin/pytest tests/integration/test_storage_repositories.py`

## Linked Linear
- RHE-12, RHE-13
