### PR TITLE
feat: implement telegram draft approval and snooze commands

### DIFF
--- a/apps/api/src/helm_api/services/action_service.py
+++ b/apps/api/src/helm_api/services/action_service.py
@@ -1,3 +1,25 @@
 def list_actions() -> list[dict]:
-    # TODO(v1-phase2): query action_items from storage repository.
-    return []
+    from helm_storage.db import SessionLocal
+    from helm_storage.models import ActionItemORM
+    from sqlalchemy import select
+    from sqlalchemy.exc import SQLAlchemyError
+
+    try:
+        with SessionLocal() as session:
+            stmt = (
+                select(ActionItemORM)
+                .where(ActionItemORM.status == "open")
+                .order_by(ActionItemORM.priority.asc(), ActionItemORM.created_at.asc())
+            )
+            records = list(session.scalars(stmt).all())
+            return [
+                {
+                    "id": item.id,
+                    "title": item.title,
+                    "priority": item.priority,
+                    "status": item.status,
+                }
+                for item in records
+            ]
+    except SQLAlchemyError:
+        return []

--- a/apps/api/src/helm_api/services/draft_service.py
+++ b/apps/api/src/helm_api/services/draft_service.py
@@ -1,3 +1,25 @@
 def list_drafts() -> list[dict]:
-    # TODO(v1-phase2): query draft_replies from storage repository.
-    return []
+    from helm_storage.db import SessionLocal
+    from helm_storage.models import DraftReplyORM
+    from sqlalchemy import select
+    from sqlalchemy.exc import SQLAlchemyError
+
+    try:
+        with SessionLocal() as session:
+            stmt = (
+                select(DraftReplyORM)
+                .where(DraftReplyORM.status.in_(("pending", "snoozed")))
+                .order_by(DraftReplyORM.created_at.asc())
+            )
+            records = list(session.scalars(stmt).all())
+            return [
+                {
+                    "id": draft.id,
+                    "channel_type": draft.channel_type,
+                    "status": draft.status,
+                    "preview": draft.draft_text[:120],
+                }
+                for draft in records
+            ]
+    except SQLAlchemyError:
+        return []

--- a/apps/telegram-bot/src/helm_telegram_bot/commands/actions.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/commands/actions.py
@@ -2,10 +2,21 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from helm_telegram_bot.commands.common import reject_if_unauthorized
+from helm_telegram_bot.services.command_service import TelegramCommandService
+
+_service = TelegramCommandService()
 
 
 async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if await reject_if_unauthorized(update, context):
         return
-    # TODO(v1-phase2): render open action items from storage.
-    await update.message.reply_text("No actions yet.")
+    if not update.message:
+        return
+    actions = _service.list_open_actions()
+    if not actions:
+        await update.message.reply_text("No open actions.")
+        return
+    lines = ["Open actions:"]
+    for item in actions:
+        lines.append(f"{item.id}: P{item.priority} {item.title}")
+    await update.message.reply_text("\n".join(lines))

--- a/apps/telegram-bot/src/helm_telegram_bot/commands/approve.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/commands/approve.py
@@ -1,11 +1,20 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from helm_telegram_bot.commands.common import reject_if_unauthorized
+from helm_telegram_bot.commands.common import parse_single_id_arg, reject_if_unauthorized
+from helm_telegram_bot.services.command_service import TelegramCommandService
+
+_service = TelegramCommandService()
 
 
 async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if await reject_if_unauthorized(update, context):
         return
-    # TODO(v1-phase2): parse /approve <id> and transition draft state.
-    await update.message.reply_text("Approve flow not implemented yet.")
+    if not update.message:
+        return
+    draft_id = parse_single_id_arg(context.args)
+    if draft_id is None:
+        await update.message.reply_text("Usage: /approve <id>")
+        return
+    result = _service.approve_draft(draft_id)
+    await update.message.reply_text(result.message)

--- a/apps/telegram-bot/src/helm_telegram_bot/commands/common.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/commands/common.py
@@ -4,6 +4,21 @@ from telegram.ext import ContextTypes
 from helm_telegram_bot.guards import is_allowed_user
 
 
+def parse_single_id_arg(args: list[str]) -> int | None:
+    if len(args) != 1:
+        return None
+    raw_value = args[0].strip()
+    if not raw_value:
+        return None
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
 async def reject_if_unauthorized(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     if is_allowed_user(update):
         return False

--- a/apps/telegram-bot/src/helm_telegram_bot/commands/drafts.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/commands/drafts.py
@@ -2,10 +2,23 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from helm_telegram_bot.commands.common import reject_if_unauthorized
+from helm_telegram_bot.services.command_service import TelegramCommandService
+
+_service = TelegramCommandService()
 
 
 async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if await reject_if_unauthorized(update, context):
         return
-    # TODO(v1-phase2): render pending drafts list and IDs.
-    await update.message.reply_text("No drafts yet.")
+    if not update.message:
+        return
+    drafts = _service.list_pending_drafts()
+    if not drafts:
+        await update.message.reply_text("No pending drafts.")
+        return
+    lines = ["Pending drafts:"]
+    for draft in drafts:
+        preview = draft.draft_text.replace("\n", " ").strip()[:80]
+        lines.append(f"{draft.id}: {draft.status} {preview}")
+    lines.append("Use /approve <id> or /snooze <id>.")
+    await update.message.reply_text("\n".join(lines))

--- a/apps/telegram-bot/src/helm_telegram_bot/commands/snooze.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/commands/snooze.py
@@ -1,11 +1,20 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from helm_telegram_bot.commands.common import reject_if_unauthorized
+from helm_telegram_bot.commands.common import parse_single_id_arg, reject_if_unauthorized
+from helm_telegram_bot.services.command_service import TelegramCommandService
+
+_service = TelegramCommandService()
 
 
 async def handle(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if await reject_if_unauthorized(update, context):
         return
-    # TODO(v1-phase2): parse /snooze <id> and set follow-up reminder.
-    await update.message.reply_text("Snooze flow not implemented yet.")
+    if not update.message:
+        return
+    draft_id = parse_single_id_arg(context.args)
+    if draft_id is None:
+        await update.message.reply_text("Usage: /snooze <id>")
+        return
+    result = _service.snooze_draft(draft_id)
+    await update.message.reply_text(result.message)

--- a/apps/telegram-bot/src/helm_telegram_bot/services/__init__.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/services/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram bot service wiring for command handlers."""

--- a/apps/telegram-bot/src/helm_telegram_bot/services/command_service.py
+++ b/apps/telegram-bot/src/helm_telegram_bot/services/command_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from helm_storage.db import SessionLocal
+from helm_storage.models import ActionItemORM, DraftReplyORM
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+
+@dataclass(frozen=True, slots=True)
+class DraftTransitionResult:
+    ok: bool
+    message: str
+
+
+class TelegramCommandService:
+    def list_open_actions(self, *, limit: int = 5) -> list[ActionItemORM]:
+        try:
+            with SessionLocal() as session:
+                stmt = (
+                    select(ActionItemORM)
+                    .where(ActionItemORM.status == "open")
+                    .order_by(ActionItemORM.priority.asc(), ActionItemORM.created_at.asc())
+                    .limit(limit)
+                )
+                return list(session.scalars(stmt).all())
+        except SQLAlchemyError:
+            return []
+
+    def list_pending_drafts(self, *, limit: int = 5) -> list[DraftReplyORM]:
+        try:
+            with SessionLocal() as session:
+                stmt = (
+                    select(DraftReplyORM)
+                    .where(DraftReplyORM.status.in_(("pending", "snoozed")))
+                    .order_by(DraftReplyORM.created_at.asc())
+                    .limit(limit)
+                )
+                return list(session.scalars(stmt).all())
+        except SQLAlchemyError:
+            return []
+
+    def approve_draft(self, draft_id: int) -> DraftTransitionResult:
+        try:
+            with SessionLocal() as session:
+                draft = session.get(DraftReplyORM, draft_id)
+                if draft is None:
+                    return DraftTransitionResult(ok=False, message=f"Draft {draft_id} not found.")
+                if draft.status not in {"pending", "snoozed"}:
+                    return DraftTransitionResult(
+                        ok=False, message=f"Draft {draft_id} is {draft.status}; cannot approve."
+                    )
+                draft.status = "approved"
+                session.commit()
+                return DraftTransitionResult(
+                    ok=True, message=f"Approved draft {draft_id}. Not sent yet."
+                )
+        except SQLAlchemyError:
+            return DraftTransitionResult(ok=False, message="Storage unavailable.")
+
+    def snooze_draft(self, draft_id: int) -> DraftTransitionResult:
+        try:
+            with SessionLocal() as session:
+                draft = session.get(DraftReplyORM, draft_id)
+                if draft is None:
+                    return DraftTransitionResult(ok=False, message=f"Draft {draft_id} not found.")
+                if draft.status != "pending":
+                    return DraftTransitionResult(
+                        ok=False, message=f"Draft {draft_id} is {draft.status}; cannot snooze."
+                    )
+                draft.status = "snoozed"
+                session.commit()
+                return DraftTransitionResult(
+                    ok=True, message=f"Snoozed draft {draft_id} for later review."
+                )
+        except SQLAlchemyError:
+            return DraftTransitionResult(ok=False, message="Storage unavailable.")

--- a/packages/storage/src/helm_storage/models.py
+++ b/packages/storage/src/helm_storage/models.py
@@ -17,4 +17,16 @@ class ActionItemORM(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
 
 
+class DraftReplyORM(Base):
+    __tablename__ = "draft_replies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    channel_type: Mapped[str] = mapped_column(String(64), nullable=False, default="email")
+    thread_id: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    draft_text: Mapped[str] = mapped_column(Text(), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+
+
 # TODO(v1-phase1): add the complete entity set from the V1 spec.

--- a/tests/unit/test_telegram_commands.py
+++ b/tests/unit/test_telegram_commands.py
@@ -1,0 +1,125 @@
+import pytest
+from helm_telegram_bot.commands import approve, common, digest, snooze
+from helm_telegram_bot.services.command_service import DraftTransitionResult
+
+
+class _Message:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+class _Update:
+    def __init__(self, *, user_id: int = 1) -> None:
+        self.message = _Message()
+        self.effective_user = type("User", (), {"id": user_id})()
+
+
+class _Context:
+    def __init__(self, args: list[str]) -> None:
+        self.args = args
+
+
+def test_parse_single_id_arg() -> None:
+    assert common.parse_single_id_arg(["42"]) == 42
+    assert common.parse_single_id_arg([]) is None
+    assert common.parse_single_id_arg(["abc"]) is None
+    assert common.parse_single_id_arg(["0"]) is None
+    assert common.parse_single_id_arg(["1", "2"]) is None
+
+
+@pytest.mark.asyncio
+async def test_reject_if_unauthorized_replies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(common, "is_allowed_user", lambda _update: False)
+    update = _Update()
+
+    rejected = await common.reject_if_unauthorized(update, _Context(args=[]))
+
+    assert rejected is True
+    assert update.message.replies == ["Unauthorized user."]
+
+
+@pytest.mark.asyncio
+async def test_approve_usage_message_when_id_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(approve, "reject_if_unauthorized", _allow)
+    update = _Update()
+
+    await approve.handle(update, _Context(args=[]))
+
+    assert update.message.replies == ["Usage: /approve <id>"]
+
+
+@pytest.mark.asyncio
+async def test_approve_parses_id_and_calls_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def __init__(self) -> None:
+            self.seen_id: int | None = None
+
+        def approve_draft(self, draft_id: int) -> DraftTransitionResult:
+            self.seen_id = draft_id
+            return DraftTransitionResult(ok=True, message="Approved draft 7. Not sent yet.")
+
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    service = _Service()
+    monkeypatch.setattr(approve, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(approve, "_service", service)
+    update = _Update()
+
+    await approve.handle(update, _Context(args=["7"]))
+
+    assert service.seen_id == 7
+    assert update.message.replies == ["Approved draft 7. Not sent yet."]
+
+
+@pytest.mark.asyncio
+async def test_approve_unauthorized_short_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def approve_draft(self, draft_id: int) -> DraftTransitionResult:
+            raise AssertionError(f"service should not be called: {draft_id}")
+
+    async def _deny(_update: _Update, _context: _Context) -> bool:
+        return True
+
+    monkeypatch.setattr(approve, "reject_if_unauthorized", _deny)
+    monkeypatch.setattr(approve, "_service", _Service())
+    update = _Update()
+
+    await approve.handle(update, _Context(args=["9"]))
+
+    assert update.message.replies == []
+
+
+@pytest.mark.asyncio
+async def test_snooze_usage_message_when_id_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(snooze, "reject_if_unauthorized", _allow)
+    update = _Update()
+
+    await snooze.handle(update, _Context(args=["oops"]))
+
+    assert update.message.replies == ["Usage: /snooze <id>"]
+
+
+@pytest.mark.asyncio
+async def test_digest_command_replies_with_generated_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(digest, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(digest, "build_daily_digest", lambda: "Daily Brief\n1. Ship feature.")
+    update = _Update()
+
+    await digest.handle(update, _Context(args=[]))
+
+    assert update.message.replies == ["Daily Brief\n1. Ship feature."]


### PR DESCRIPTION
## Summary
- make Telegram `/actions` and `/drafts` data-backed from storage models
- implement `/approve <id>` and `/snooze <id>` parsing and draft status transitions
- keep outbound behavior human-supervised (`Approved ... Not sent yet.`)
- enforce allowed-user guard short-circuit behavior through existing command guard
- wire concise command service for telegram handlers

## Tests
- `PYTHONPATH="apps/api/src:apps/worker/src:apps/telegram-bot/src:packages/domain/src:packages/storage/src:packages/connectors/src:packages/agents/src:packages/orchestration/src:packages/llm/src:packages/observability/src" /Users/ankush/git/helm/.venv/bin/pytest tests/unit/test_telegram_commands.py tests/unit/test_bot_guard.py tests/integration/test_routes.py`
- `/Users/ankush/git/helm/.venv/bin/ruff check apps/telegram-bot/src/helm_telegram_bot/commands apps/telegram-bot/src/helm_telegram_bot/services apps/api/src/helm_api/services packages/storage/src/helm_storage/models.py tests/unit/test_telegram_commands.py`

## Scope Notes
- Telegram-first behavior only; no frontend/dashboard work.
- Responses remain concise and operational.

## Linked Linear
- RHE-16, RHE-17
