### PR TITLE
feat: add telegram command flow service test coverage

### DIFF
--- a/tests/unit/test_telegram_command_service.py
+++ b/tests/unit/test_telegram_command_service.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+
+import pytest
+from helm_telegram_bot.services import command_service
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class _Session(AbstractContextManager[object]):
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+
+class _BrokenSession(AbstractContextManager[object]):
+    def __enter__(self) -> object:
+        raise SQLAlchemyError("db down")
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+
+@dataclass
+class _Action:
+    id: int
+
+
+@dataclass
+class _Draft:
+    id: int
+    status: str
+
+
+class _ActionRepo:
+    def __init__(self, _session: object) -> None:
+        self._data = [_Action(id=i) for i in range(1, 8)]
+
+    def list_open(self) -> list[_Action]:
+        return self._data
+
+
+class _DraftRepo:
+    def __init__(self, _session: object) -> None:
+        self._by_id: dict[int, _Draft] = {
+            1: _Draft(id=1, status="pending"),
+            2: _Draft(id=2, status="snoozed"),
+            3: _Draft(id=3, status="approved"),
+        }
+        self.approved_ids: list[int] = []
+        self.snoozed_ids: list[int] = []
+
+    def list_pending(self) -> list[_Draft]:
+        return [_Draft(id=i, status="pending") for i in range(1, 8)]
+
+    def get_by_id(self, draft_id: int) -> _Draft | None:
+        return self._by_id.get(draft_id)
+
+    def approve(self, draft_id: int) -> None:
+        self.approved_ids.append(draft_id)
+
+    def snooze(self, draft_id: int) -> None:
+        self.snoozed_ids.append(draft_id)
+
+
+@pytest.mark.parametrize("limit", [1, 3, 5])
+def test_list_open_actions_applies_limit(monkeypatch: pytest.MonkeyPatch, limit: int) -> None:
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyActionItemRepository", _ActionRepo)
+
+    service = command_service.TelegramCommandService()
+
+    actions = service.list_open_actions(limit=limit)
+
+    assert [a.id for a in actions] == list(range(1, limit + 1))
+
+
+@pytest.mark.parametrize("limit", [1, 4, 6])
+def test_list_pending_drafts_applies_limit(monkeypatch: pytest.MonkeyPatch, limit: int) -> None:
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", _DraftRepo)
+
+    service = command_service.TelegramCommandService()
+
+    drafts = service.list_pending_drafts(limit=limit)
+
+    assert [d.id for d in drafts] == list(range(1, limit + 1))
+
+
+def test_list_queries_handle_storage_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command_service, "SessionLocal", _BrokenSession)
+
+    service = command_service.TelegramCommandService()
+
+    assert service.list_open_actions() == []
+    assert service.list_pending_drafts() == []
+
+
+def test_approve_draft_happy_path_from_pending(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.approve_draft(1)
+
+    assert result.ok is True
+    assert result.message == "Approved draft 1. Not sent yet."
+    assert repo.approved_ids == [1]
+
+
+def test_approve_draft_allows_snoozed(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.approve_draft(2)
+
+    assert result.ok is True
+    assert repo.approved_ids == [2]
+
+
+def test_approve_draft_rejects_non_actionable_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.approve_draft(3)
+
+    assert result.ok is False
+    assert result.message == "Draft 3 is approved; cannot approve."
+    assert repo.approved_ids == []
+
+
+def test_approve_draft_handles_missing_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.approve_draft(999)
+
+    assert result.ok is False
+    assert result.message == "Draft 999 not found."
+
+
+def test_approve_draft_handles_storage_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command_service, "SessionLocal", _BrokenSession)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.approve_draft(1)
+
+    assert result.ok is False
+    assert result.message == "Storage unavailable."
+
+
+def test_snooze_draft_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.snooze_draft(1)
+
+    assert result.ok is True
+    assert result.message == "Snoozed draft 1 for later review."
+    assert repo.snoozed_ids == [1]
+
+
+def test_snooze_draft_rejects_non_pending_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.snooze_draft(2)
+
+    assert result.ok is False
+    assert result.message == "Draft 2 is snoozed; cannot snooze."
+    assert repo.snoozed_ids == []
+
+
+def test_snooze_draft_handles_missing_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _DraftRepo(object())
+    monkeypatch.setattr(command_service, "SessionLocal", _Session)
+    monkeypatch.setattr(command_service, "SQLAlchemyDraftReplyRepository", lambda _session: repo)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.snooze_draft(999)
+
+    assert result.ok is False
+    assert result.message == "Draft 999 not found."
+
+
+def test_snooze_draft_handles_storage_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command_service, "SessionLocal", _BrokenSession)
+
+    service = command_service.TelegramCommandService()
+
+    result = service.snooze_draft(1)
+
+    assert result.ok is False
+    assert result.message == "Storage unavailable."

--- a/tests/unit/test_telegram_commands.py
+++ b/tests/unit/test_telegram_commands.py
@@ -1,5 +1,5 @@
 import pytest
-from helm_telegram_bot.commands import approve, common, digest, snooze
+from helm_telegram_bot.commands import actions, approve, common, digest, drafts, snooze
 from helm_telegram_bot.services.command_service import DraftTransitionResult
 
 
@@ -20,6 +20,20 @@ class _Update:
 class _Context:
     def __init__(self, args: list[str]) -> None:
         self.args = args
+
+
+class _Action:
+    def __init__(self, item_id: int, priority: int, title: str) -> None:
+        self.id = item_id
+        self.priority = priority
+        self.title = title
+
+
+class _Draft:
+    def __init__(self, draft_id: int, status: str, draft_text: str) -> None:
+        self.id = draft_id
+        self.status = status
+        self.draft_text = draft_text
 
 
 def test_parse_single_id_arg() -> None:
@@ -123,3 +137,126 @@ async def test_digest_command_replies_with_generated_digest(
     await digest.handle(update, _Context(args=[]))
 
     assert update.message.replies == ["Daily Brief\n1. Ship feature."]
+
+
+@pytest.mark.asyncio
+async def test_actions_command_replies_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_open_actions(self) -> list[_Action]:
+            return []
+
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(actions, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(actions, "_service", _Service())
+    update = _Update()
+
+    await actions.handle(update, _Context(args=[]))
+
+    assert update.message.replies == ["No open actions."]
+
+
+@pytest.mark.asyncio
+async def test_actions_command_formats_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_open_actions(self) -> list[_Action]:
+            return [
+                _Action(item_id=3, priority=1, title="Reply to recruiter"),
+                _Action(item_id=2, priority=2, title="Review draft"),
+            ]
+
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(actions, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(actions, "_service", _Service())
+    update = _Update()
+
+    await actions.handle(update, _Context(args=[]))
+
+    assert update.message.replies == [
+        "Open actions:\n3: P1 Reply to recruiter\n2: P2 Review draft"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_drafts_command_replies_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_pending_drafts(self) -> list[_Draft]:
+            return []
+
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(drafts, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(drafts, "_service", _Service())
+    update = _Update()
+
+    await drafts.handle(update, _Context(args=[]))
+
+    assert update.message.replies == ["No pending drafts."]
+
+
+@pytest.mark.asyncio
+async def test_drafts_command_formats_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_pending_drafts(self) -> list[_Draft]:
+            return [
+                _Draft(draft_id=1, status="pending", draft_text="First line\nSecond line"),
+                _Draft(draft_id=2, status="snoozed", draft_text="Need follow-up"),
+            ]
+
+    async def _allow(_update: _Update, _context: _Context) -> bool:
+        return False
+
+    monkeypatch.setattr(drafts, "reject_if_unauthorized", _allow)
+    monkeypatch.setattr(drafts, "_service", _Service())
+    update = _Update()
+
+    await drafts.handle(update, _Context(args=[]))
+
+    assert update.message.replies == [
+        (
+            "Pending drafts:\n"
+            "1: pending First line Second line\n"
+            "2: snoozed Need follow-up\n"
+            "Use /approve <id> or /snooze <id>."
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_actions_unauthorized_short_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_open_actions(self) -> list[_Action]:
+            raise AssertionError("service should not be called")
+
+    async def _deny(_update: _Update, _context: _Context) -> bool:
+        return True
+
+    monkeypatch.setattr(actions, "reject_if_unauthorized", _deny)
+    monkeypatch.setattr(actions, "_service", _Service())
+    update = _Update()
+
+    await actions.handle(update, _Context(args=[]))
+
+    assert update.message.replies == []
+
+
+@pytest.mark.asyncio
+async def test_drafts_unauthorized_short_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Service:
+        def list_pending_drafts(self) -> list[_Draft]:
+            raise AssertionError("service should not be called")
+
+    async def _deny(_update: _Update, _context: _Context) -> bool:
+        return True
+
+    monkeypatch.setattr(drafts, "reject_if_unauthorized", _deny)
+    monkeypatch.setattr(drafts, "_service", _Service())
+    update = _Update()
+
+    await drafts.handle(update, _Context(args=[]))
+
+    assert update.message.replies == []


### PR DESCRIPTION
## Summary
- expand coverage for telegram /actions, /drafts, /approve, and /snooze flows
- add dedicated command service tests for transition and listing behavior
- keep guard + parsing scenarios covered for scaffold stage

## Linked Work
- Linked Linear: RHE-16, RHE-17

## Validation
- bash scripts/lint.sh
- bash scripts/test.sh
