### PR TITLE
feat: add digest ranking and agent run visibility scaffolding

### DIFF
--- a/apps/api/src/helm_api/main.py
+++ b/apps/api/src/helm_api/main.py
@@ -1,21 +1,16 @@
 from fastapi import FastAPI
 
 from helm_api.config import settings
-from helm_api.routers import actions, drafts, study, workflows
-from helm_api.services.status_service import get_runtime_status
+from helm_api.routers import actions, drafts, status, study, workflows
 
 app = FastAPI(title="helm-api", version="0.1.0")
 app.include_router(actions.router)
 app.include_router(drafts.router)
 app.include_router(study.router)
 app.include_router(workflows.router)
+app.include_router(status.router)
 
 
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok", "env": settings.app_env}
-
-
-@app.get("/v1/status")
-def status() -> dict[str, str]:
-    return get_runtime_status()

--- a/apps/api/src/helm_api/routers/status.py
+++ b/apps/api/src/helm_api/routers/status.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Query
+
+from helm_api.schemas import AgentRunFailureResponse, StatusResponse
+from helm_api.services.status_service import get_runtime_status, list_recent_failed_agent_runs
+
+router = APIRouter(prefix="/v1/status", tags=["status"])
+
+
+@router.get("", response_model=StatusResponse)
+def get_status() -> StatusResponse:
+    return StatusResponse(**get_runtime_status())
+
+
+@router.get("/agent-runs/failures", response_model=list[AgentRunFailureResponse])
+def get_failed_agent_runs(
+    limit: int = Query(default=20, ge=1, le=100),
+) -> list[AgentRunFailureResponse]:
+    return [AgentRunFailureResponse(**item) for item in list_recent_failed_agent_runs(limit=limit)]

--- a/apps/api/src/helm_api/routers/workflows.py
+++ b/apps/api/src/helm_api/routers/workflows.py
@@ -1,10 +1,32 @@
 from fastapi import APIRouter
-from helm_agents.digest_agent import build_daily_digest
+from helm_agents.digest_agent import generate_daily_digest
+from helm_observability.agent_runs import record_agent_run
 
 router = APIRouter(prefix="/v1/workflows", tags=["workflows"])
 
 
 @router.post("/digest/run")
-def run_digest() -> dict[str, str]:
-    text = build_daily_digest()
-    return {"status": "ok", "preview": text[:120]}
+def run_digest() -> dict[str, str | int]:
+    result = None
+
+    def _execute() -> None:
+        nonlocal result
+        result = generate_daily_digest()
+
+    record_agent_run(
+        agent_name="digest_agent",
+        source_type="api",
+        source_id="v1/workflows/digest/run",
+        execute=_execute,
+    )
+
+    if result is None:
+        return {"status": "error", "preview": "Digest run failed.", "action_count": 0}
+
+    return {
+        "status": "ok",
+        "preview": result.text[:120],
+        "action_count": result.action_count,
+        "digest_item_count": result.digest_item_count,
+        "pending_draft_count": result.pending_draft_count,
+    }

--- a/apps/api/src/helm_api/schemas.py
+++ b/apps/api/src/helm_api/schemas.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
 class StatusResponse(BaseModel):
     service: str
     state: str
+    recent_failed_runs: int = 0
 
 
 class ActionItemResponse(BaseModel):
@@ -23,3 +26,14 @@ class DraftResponse(BaseModel):
 class StudyIngestRequest(BaseModel):
     source_type: str = "manual"
     raw_text: str
+
+
+class AgentRunFailureResponse(BaseModel):
+    id: int
+    agent_name: str
+    source_type: str
+    source_id: str | None
+    status: str
+    started_at: datetime
+    completed_at: datetime | None
+    error_message: str | None

--- a/apps/api/src/helm_api/services/status_service.py
+++ b/apps/api/src/helm_api/services/status_service.py
@@ -1,3 +1,37 @@
-def get_runtime_status() -> dict[str, str]:
-    # TODO(v1-phase2): include DB ping, worker heartbeat, and connector statuses.
-    return {"service": "api", "state": "bootstrapped"}
+from helm_storage.db import SessionLocal
+from helm_storage.repositories.agent_runs import SQLAlchemyAgentRunRepository
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def get_runtime_status() -> dict[str, str | int]:
+    failed_runs = 0
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyAgentRunRepository(session)
+            failed_runs = len(repository.list_recent_failed(limit=10))
+    except SQLAlchemyError:
+        failed_runs = 0
+
+    return {"service": "api", "state": "bootstrapped", "recent_failed_runs": failed_runs}
+
+
+def list_recent_failed_agent_runs(limit: int = 20) -> list[dict]:
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyAgentRunRepository(session)
+            records = repository.list_recent_failed(limit=limit)
+            return [
+                {
+                    "id": run.id,
+                    "agent_name": run.agent_name,
+                    "source_type": run.source_type,
+                    "source_id": run.source_id,
+                    "status": run.status,
+                    "started_at": run.started_at,
+                    "completed_at": run.completed_at,
+                    "error_message": run.error_message,
+                }
+                for run in records
+            ]
+    except SQLAlchemyError:
+        return []

--- a/apps/worker/src/helm_worker/main.py
+++ b/apps/worker/src/helm_worker/main.py
@@ -1,5 +1,6 @@
 import time
 
+from helm_observability.agent_runs import record_agent_run
 from helm_observability.logging import get_logger, setup_logging
 
 from helm_worker.config import settings
@@ -14,7 +15,12 @@ def run() -> None:
     while True:
         for name, job in JOBS.items():
             try:
-                job()
+                record_agent_run(
+                    agent_name=name,
+                    source_type="worker",
+                    source_id="scheduler",
+                    execute=job,
+                )
             except Exception as exc:  # noqa: BLE001
                 logger.error("worker_job_failed", job=name, error=str(exc))
         time.sleep(settings.worker_poll_seconds)

--- a/docs/contracts/api.md
+++ b/docs/contracts/api.md
@@ -6,9 +6,10 @@ Base path: `/v1`
 
 - `GET /healthz`: liveness.
 - `GET /v1/status`: coarse runtime status.
+- `GET /v1/status/agent-runs/failures`: list recent failed agent runs for debug visibility.
 - `GET /v1/actions`: list action items (placeholder).
 - `GET /v1/drafts`: list drafts (placeholder).
 - `POST /v1/study/ingest`: manual study ingest (placeholder).
-- `POST /v1/workflows/digest/run`: trigger digest generation (placeholder).
+- `POST /v1/workflows/digest/run`: trigger digest generation with ranked artifact counts.
 
 TODO(v1-phase2+): add schemas and behavior contract examples.

--- a/docs/contracts/workflows.md
+++ b/docs/contracts/workflows.md
@@ -24,6 +24,7 @@ Input:
 Output:
 
 - concise Telegram digest
+- ranked digest context from open actions, digest items, and pending drafts
 - agent run log
 
 ## Study ingest workflow

--- a/packages/agents/src/helm_agents/digest_agent.py
+++ b/packages/agents/src/helm_agents/digest_agent.py
@@ -1,8 +1,68 @@
+from dataclasses import dataclass
+
 from helm_observability.logging import get_logger
+from helm_storage.db import SessionLocal
+from helm_storage.repositories.action_items import SQLAlchemyActionItemRepository
+from helm_storage.repositories.digest_items import SQLAlchemyDigestItemRepository
+from helm_storage.repositories.draft_replies import SQLAlchemyDraftReplyRepository
+from sqlalchemy.exc import SQLAlchemyError
+
+
+@dataclass(slots=True)
+class DigestBuildResult:
+    text: str
+    action_count: int
+    digest_item_count: int
+    pending_draft_count: int
+
+
+def generate_daily_digest(limit: int = 5) -> DigestBuildResult:
+    logger = get_logger("helm_agents.digest")
+    try:
+        with SessionLocal() as session:
+            actions = SQLAlchemyActionItemRepository(session).list_open()[:limit]
+            digest_items = SQLAlchemyDigestItemRepository(session).list_ranked(limit=limit)
+            drafts = SQLAlchemyDraftReplyRepository(session).list_pending()[:limit]
+    except SQLAlchemyError:
+        logger.warning("digest_query_failed")
+        return DigestBuildResult(
+            text="Daily Brief\nNo artifact data available yet.",
+            action_count=0,
+            digest_item_count=0,
+            pending_draft_count=0,
+        )
+
+    lines: list[str] = ["Daily Brief"]
+    if actions:
+        lines.append("Actions:")
+        lines.extend(
+            [f"- P{item.priority} {item.title}" for item in actions]
+        )
+    if digest_items:
+        lines.append("Priority Signals:")
+        lines.extend(
+            [f"- P{item.priority} [{item.domain}] {item.title}" for item in digest_items]
+        )
+    if drafts:
+        lines.append("Pending Drafts:")
+        lines.extend([f"- #{draft.id} ({draft.channel_type}) {draft.status}" for draft in drafts])
+    if len(lines) == 1:
+        lines.append("No open actions, priority signals, or pending drafts.")
+
+    text = "\n".join(lines)
+    logger.info(
+        "digest_built",
+        actions=len(actions),
+        digest_items=len(digest_items),
+        drafts=len(drafts),
+    )
+    return DigestBuildResult(
+        text=text,
+        action_count=len(actions),
+        digest_item_count=len(digest_items),
+        pending_draft_count=len(drafts),
+    )
 
 
 def build_daily_digest() -> str:
-    logger = get_logger("helm_agents.digest")
-    logger.info("build_daily_digest_stub")
-    # TODO(v1-phase3): rank artifacts and generate concise actionable briefing.
-    return "Daily digest not implemented yet."
+    return generate_daily_digest().text

--- a/packages/observability/src/helm_observability/agent_runs.py
+++ b/packages/observability/src/helm_observability/agent_runs.py
@@ -1,0 +1,57 @@
+from collections.abc import Callable
+
+from helm_storage.db import SessionLocal
+from helm_storage.repositories.agent_runs import SQLAlchemyAgentRunRepository
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def record_agent_run(
+    *,
+    agent_name: str,
+    source_type: str,
+    source_id: str | None,
+    execute: Callable[[], None],
+) -> None:
+    run_id: int | None = None
+
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyAgentRunRepository(session)
+            run = repository.start_run(
+                agent_name=agent_name,
+                source_type=source_type,
+                source_id=source_id,
+            )
+            run_id = run.id
+    except SQLAlchemyError:
+        run_id = None
+
+    try:
+        execute()
+    except Exception as exc:  # noqa: BLE001
+        _mark_failure(run_id=run_id, error_message=str(exc))
+        raise
+
+    _mark_success(run_id=run_id)
+
+
+def _mark_success(*, run_id: int | None) -> None:
+    if run_id is None:
+        return
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyAgentRunRepository(session)
+            repository.mark_succeeded(run_id)
+    except SQLAlchemyError:
+        return
+
+
+def _mark_failure(*, run_id: int | None, error_message: str) -> None:
+    if run_id is None:
+        return
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyAgentRunRepository(session)
+            repository.mark_failed(run_id, error_message)
+    except SQLAlchemyError:
+        return

--- a/packages/storage/src/helm_storage/repositories/agent_runs.py
+++ b/packages/storage/src/helm_storage/repositories/agent_runs.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from helm_storage.models import AgentRunORM
+
+
+class SQLAlchemyAgentRunRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def start_run(
+        self,
+        *,
+        agent_name: str,
+        source_type: str,
+        source_id: str | None = None,
+    ) -> AgentRunORM:
+        run = AgentRunORM(
+            agent_name=agent_name,
+            source_type=source_type,
+            source_id=source_id,
+            status="running",
+            started_at=datetime.utcnow(),
+        )
+        self._session.add(run)
+        self._session.commit()
+        self._session.refresh(run)
+        return run
+
+    def mark_succeeded(self, run_id: int) -> None:
+        run = self.get_by_id(run_id)
+        if run is None:
+            return
+        run.status = "succeeded"
+        run.completed_at = datetime.utcnow()
+        run.error_message = None
+        self._session.add(run)
+        self._session.commit()
+
+    def mark_failed(self, run_id: int, error_message: str) -> None:
+        run = self.get_by_id(run_id)
+        if run is None:
+            return
+        run.status = "failed"
+        run.completed_at = datetime.utcnow()
+        run.error_message = error_message[:4000]
+        self._session.add(run)
+        self._session.commit()
+
+    def list_recent_failed(self, limit: int = 20) -> list[AgentRunORM]:
+        stmt = (
+            select(AgentRunORM)
+            .where(AgentRunORM.status == "failed")
+            .order_by(AgentRunORM.started_at.desc(), AgentRunORM.id.desc())
+            .limit(limit)
+        )
+        return list(self._session.execute(stmt).scalars().all())
+
+    def get_by_id(self, run_id: int) -> AgentRunORM | None:
+        stmt = select(AgentRunORM).where(AgentRunORM.id == run_id)
+        return self._session.execute(stmt).scalars().first()

--- a/packages/storage/src/helm_storage/repositories/digest_items.py
+++ b/packages/storage/src/helm_storage/repositories/digest_items.py
@@ -16,6 +16,14 @@ class SQLAlchemyDigestItemRepository:
         stmt = stmt.order_by(DigestItemORM.priority.asc(), DigestItemORM.id.desc()).limit(limit)
         return list(self._session.execute(stmt).scalars().all())
 
+    def list_ranked(self, limit: int = 5) -> list[DigestItemORM]:
+        stmt = (
+            select(DigestItemORM)
+            .order_by(DigestItemORM.priority.asc(), DigestItemORM.created_at.desc())
+            .limit(limit)
+        )
+        return list(self._session.execute(stmt).scalars().all())
+
     def create(self, item: NewDigestItem) -> DigestItemORM:
         record = DigestItemORM(
             domain=item.domain,

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -5,5 +5,6 @@ from helm_api.main import app
 def test_routes_exist() -> None:
     client = TestClient(app)
     assert client.get("/v1/status").status_code == 200
+    assert client.get("/v1/status/agent-runs/failures").status_code == 200
     assert client.get("/v1/actions").status_code == 200
     assert client.get("/v1/drafts").status_code == 200

--- a/tests/unit/test_api_status.py
+++ b/tests/unit/test_api_status.py
@@ -5,3 +5,4 @@ def test_status_shape() -> None:
     payload = get_runtime_status()
     assert payload["service"] == "api"
     assert "state" in payload
+    assert "recent_failed_runs" in payload

--- a/tests/unit/test_digest_agent.py
+++ b/tests/unit/test_digest_agent.py
@@ -1,0 +1,70 @@
+from helm_agents import digest_agent
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class _BrokenSession:
+    def __enter__(self) -> object:
+        raise SQLAlchemyError("db unavailable")
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+def test_generate_daily_digest_falls_back_on_db_failure(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(digest_agent, "SessionLocal", lambda: _BrokenSession())
+
+    result = digest_agent.generate_daily_digest()
+
+    assert result.action_count == 0
+    assert result.digest_item_count == 0
+    assert result.pending_draft_count == 0
+    assert "No artifact data available" in result.text
+
+
+class _Session:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+class _ActionRepo:
+    def __init__(self, _session: object) -> None:
+        pass
+
+    def list_open(self) -> list[object]:
+        return [type("Action", (), {"priority": 1, "title": "Reply recruiter"})()]
+
+
+class _DigestRepo:
+    def __init__(self, _session: object) -> None:
+        pass
+
+    def list_ranked(self, limit: int = 5) -> list[object]:
+        assert limit == 5
+        return [type("Digest", (), {"priority": 2, "domain": "email", "title": "Hot intro"})()]
+
+
+class _DraftRepo:
+    def __init__(self, _session: object) -> None:
+        pass
+
+    def list_pending(self) -> list[object]:
+        return [type("Draft", (), {"id": 7, "channel_type": "email", "status": "pending"})()]
+
+
+def test_generate_daily_digest_uses_ranked_sources(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(digest_agent, "SessionLocal", lambda: _Session())
+    monkeypatch.setattr(digest_agent, "SQLAlchemyActionItemRepository", _ActionRepo)
+    monkeypatch.setattr(digest_agent, "SQLAlchemyDigestItemRepository", _DigestRepo)
+    monkeypatch.setattr(digest_agent, "SQLAlchemyDraftReplyRepository", _DraftRepo)
+
+    result = digest_agent.generate_daily_digest()
+
+    assert result.action_count == 1
+    assert result.digest_item_count == 1
+    assert result.pending_draft_count == 1
+    assert "Actions:" in result.text
+    assert "Priority Signals:" in result.text
+    assert "Pending Drafts:" in result.text


### PR DESCRIPTION
## Summary
- add digest ranking + formatting scaffold for daily brief generation
- add agent run recording helpers and failed-run visibility endpoint scaffolding
- wire API status/workflow routes and worker hooks for observability
- add focused tests for digest logic and status reporting

## Linked Work
- Linked Linear: RHE-18, RHE-20

## Validation
- bash scripts/lint.sh
- bash scripts/test.sh
