### PR TITLE
feat: wire manual study ingest to durable artifacts

### DIFF
--- a/apps/api/src/helm_api/routers/study.py
+++ b/apps/api/src/helm_api/routers/study.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter
 
-from helm_api.schemas import StudyIngestRequest
+from helm_api.schemas import StudyIngestRequest, StudyIngestResponse
 from helm_api.services.study_service import ingest_manual_study_note
 
 router = APIRouter(prefix="/v1/study", tags=["study"])
 
 
-@router.post("/ingest")
-def ingest_study(payload: StudyIngestRequest) -> dict:
-    return ingest_manual_study_note(source_type=payload.source_type, raw_text=payload.raw_text)
+@router.post("/ingest", response_model=StudyIngestResponse)
+def ingest_study(payload: StudyIngestRequest) -> StudyIngestResponse:
+    return StudyIngestResponse(
+        **ingest_manual_study_note(source_type=payload.source_type, raw_text=payload.raw_text)
+    )

--- a/apps/api/src/helm_api/schemas.py
+++ b/apps/api/src/helm_api/schemas.py
@@ -28,6 +28,17 @@ class StudyIngestRequest(BaseModel):
     raw_text: str
 
 
+class StudyIngestResponse(BaseModel):
+    status: str
+    source_type: str
+    chars: int
+    summary: str
+    task_count: int
+    gap_count: int
+    session_id: int | None
+    persisted: bool
+
+
 class AgentRunFailureResponse(BaseModel):
     id: int
     agent_name: str

--- a/apps/api/src/helm_api/services/study_service.py
+++ b/apps/api/src/helm_api/services/study_service.py
@@ -1,3 +1,35 @@
 def ingest_manual_study_note(source_type: str, raw_text: str) -> dict:
-    # TODO(v1-phase4): call study workflow and persist session/task artifacts.
-    return {"status": "accepted", "source_type": source_type, "chars": len(raw_text)}
+    from helm_agents.study_agent import extract_study_artifacts
+    from helm_storage.db import SessionLocal
+    from helm_storage.repositories.study_ingest import SQLAlchemyStudyIngestRepository
+    from sqlalchemy.exc import SQLAlchemyError
+
+    artifacts = extract_study_artifacts(raw_text=raw_text)
+    session_id: int | None = None
+    persisted = False
+
+    try:
+        with SessionLocal() as session:
+            repository = SQLAlchemyStudyIngestRepository(session)
+            study_session = repository.create_session_with_artifacts(
+                source_type=source_type,
+                raw_text=raw_text,
+                summary=artifacts["summary"],
+                knowledge_gaps=artifacts["knowledge_gaps"],
+                learning_tasks=artifacts["learning_tasks"],
+            )
+            session_id = study_session.id
+            persisted = True
+    except SQLAlchemyError:
+        persisted = False
+
+    return {
+        "status": "accepted",
+        "source_type": source_type,
+        "chars": len(raw_text),
+        "summary": artifacts["summary"],
+        "task_count": len(artifacts["learning_tasks"]),
+        "gap_count": len(artifacts["knowledge_gaps"]),
+        "session_id": session_id,
+        "persisted": persisted,
+    }

--- a/docs/contracts/api.md
+++ b/docs/contracts/api.md
@@ -9,7 +9,7 @@ Base path: `/v1`
 - `GET /v1/status/agent-runs/failures`: list recent failed agent runs for debug visibility.
 - `GET /v1/actions`: list action items (placeholder).
 - `GET /v1/drafts`: list drafts (placeholder).
-- `POST /v1/study/ingest`: manual study ingest (placeholder).
+- `POST /v1/study/ingest`: manual study ingest that extracts summary/tasks/gaps and persists `study_sessions`, `learning_tasks`, and `knowledge_gaps` when DB is available.
 - `POST /v1/workflows/digest/run`: trigger digest generation with ranked artifact counts.
 
 TODO(v1-phase2+): add schemas and behavior contract examples.

--- a/packages/agents/src/helm_agents/study_agent.py
+++ b/packages/agents/src/helm_agents/study_agent.py
@@ -1,0 +1,106 @@
+def extract_study_artifacts(raw_text: str) -> dict:
+    # TODO(v1-phase4, owner:packages/agents): replace heuristics with
+    # validated LLM structured extraction.
+    lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
+    summary = _build_summary(lines, raw_text)
+    knowledge_gaps = _extract_knowledge_gaps(lines)
+    learning_tasks = _extract_learning_tasks(lines, knowledge_gaps)
+    return {"summary": summary, "knowledge_gaps": knowledge_gaps, "learning_tasks": learning_tasks}
+
+
+def _build_summary(lines: list[str], raw_text: str) -> str:
+    if not lines:
+        return "No study notes provided."
+    candidate = " ".join(lines[:3])
+    if len(candidate) <= 280:
+        return candidate
+    trimmed = raw_text.strip().replace("\n", " ")
+    return f"{trimmed[:277]}..." if len(trimmed) > 280 else trimmed
+
+
+def _extract_knowledge_gaps(lines: list[str]) -> list[dict]:
+    gaps: list[dict] = []
+    for line in lines:
+        lowered = line.lower()
+        if _is_gap_line(lowered):
+            description = _normalize_prefix(line)
+            topic = _extract_topic(description)
+            gaps.append(
+                {
+                    "topic": topic,
+                    "description": description,
+                    "severity": _infer_gap_severity(lowered),
+                }
+            )
+    return gaps
+
+
+def _extract_learning_tasks(lines: list[str], gaps: list[dict]) -> list[dict]:
+    tasks: list[dict] = []
+    for line in lines:
+        lowered = line.lower()
+        if _is_task_line(lowered):
+            task_text = _normalize_prefix(line)
+            tasks.append(
+                {
+                    "title": _truncate(task_text, 255),
+                    "description": task_text,
+                    "priority": _infer_task_priority(lowered),
+                    "status": "open",
+                    "related_gap_index": _match_related_gap(task_text, gaps),
+                }
+            )
+    return tasks
+
+
+def _is_gap_line(lowered_line: str) -> bool:
+    return lowered_line.startswith(("gap:", "weakness:", "don't know", "struggle", "confused"))
+
+
+def _is_task_line(lowered_line: str) -> bool:
+    return lowered_line.startswith(("todo:", "task:", "next:", "- [ ]", "review:", "practice:"))
+
+
+def _normalize_prefix(line: str) -> str:
+    prefixes = ("gap:", "weakness:", "todo:", "task:", "next:", "review:", "practice:")
+    cleaned = line.strip()
+    if cleaned.startswith("- [ ]"):
+        return cleaned.removeprefix("- [ ]").strip()
+    lowered = cleaned.lower()
+    for prefix in prefixes:
+        if lowered.startswith(prefix):
+            return cleaned[len(prefix) :].strip()
+    return cleaned
+
+
+def _extract_topic(description: str) -> str:
+    topic = description.split(".")[0].split(",")[0].strip()
+    return _truncate(topic or "unknown-topic", 255)
+
+
+def _infer_gap_severity(lowered_line: str) -> str:
+    if any(token in lowered_line for token in ("blocked", "can't", "cannot", "failed")):
+        return "high"
+    if any(token in lowered_line for token in ("struggle", "confused", "weak", "unclear")):
+        return "medium"
+    return "low"
+
+
+def _infer_task_priority(lowered_line: str) -> int:
+    if "urgent" in lowered_line or "today" in lowered_line:
+        return 1
+    if "tomorrow" in lowered_line or "soon" in lowered_line:
+        return 2
+    return 3
+
+
+def _match_related_gap(task_text: str, gaps: list[dict]) -> int | None:
+    lowered_task = task_text.lower()
+    for gap_index, gap in enumerate(gaps):
+        if gap["topic"].lower() in lowered_task:
+            return gap_index
+    return None
+
+
+def _truncate(value: str, length: int) -> str:
+    return value if len(value) <= length else value[: length - 3] + "..."

--- a/packages/storage/src/helm_storage/repositories/__init__.py
+++ b/packages/storage/src/helm_storage/repositories/__init__.py
@@ -1,6 +1,7 @@
 """Storage repository implementations and contracts."""
 
 from helm_storage.repositories.action_items import SQLAlchemyActionItemRepository
+from helm_storage.repositories.agent_runs import SQLAlchemyAgentRunRepository
 from helm_storage.repositories.contracts import (
     ActionItemRepository,
     DigestItemRepository,
@@ -11,6 +12,7 @@ from helm_storage.repositories.contracts import (
 )
 from helm_storage.repositories.digest_items import SQLAlchemyDigestItemRepository
 from helm_storage.repositories.draft_replies import SQLAlchemyDraftReplyRepository
+from helm_storage.repositories.study_ingest import SQLAlchemyStudyIngestRepository
 
 __all__ = [
     "ActionItemRepository",
@@ -20,6 +22,8 @@ __all__ = [
     "NewDigestItem",
     "NewDraftReply",
     "SQLAlchemyActionItemRepository",
+    "SQLAlchemyAgentRunRepository",
     "SQLAlchemyDigestItemRepository",
     "SQLAlchemyDraftReplyRepository",
+    "SQLAlchemyStudyIngestRepository",
 ]

--- a/packages/storage/src/helm_storage/repositories/study_ingest.py
+++ b/packages/storage/src/helm_storage/repositories/study_ingest.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from helm_storage.models import KnowledgeGapORM, LearningTaskORM, StudySessionORM
+
+
+class SQLAlchemyStudyIngestRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_session_with_artifacts(
+        self,
+        source_type: str,
+        raw_text: str,
+        summary: str,
+        knowledge_gaps: list[dict],
+        learning_tasks: list[dict],
+    ) -> StudySessionORM:
+        study_session = StudySessionORM(source_type=source_type, raw_text=raw_text, summary=summary)
+        self._session.add(study_session)
+        self._session.flush()
+
+        gap_ids_by_index: dict[int, int] = {}
+        for gap_index, gap_payload in enumerate(knowledge_gaps):
+            gap = KnowledgeGapORM(
+                topic=gap_payload["topic"],
+                description=gap_payload.get("description") or gap_payload["topic"],
+                severity=_to_severity_int(gap_payload.get("severity", 2)),
+                source_session_id=study_session.id,
+            )
+            self._session.add(gap)
+            self._session.flush()
+            gap_ids_by_index[gap_index] = gap.id
+
+        for task_payload in learning_tasks:
+            due_at = task_payload.get("due_at")
+            if isinstance(due_at, str):
+                due_at = datetime.fromisoformat(due_at)
+            related_gap_index = task_payload.get("related_gap_index")
+            related_gap_id = (
+                gap_ids_by_index.get(related_gap_index) if related_gap_index is not None else None
+            )
+
+            task = LearningTaskORM(
+                title=task_payload["title"],
+                description=task_payload.get("description"),
+                priority=task_payload.get("priority", 3),
+                status=task_payload.get("status", "open"),
+                due_at=due_at,
+                related_gap_id=related_gap_id,
+            )
+            self._session.add(task)
+
+        self._session.commit()
+        self._session.refresh(study_session)
+        return study_session
+
+
+def _to_severity_int(value: int | str) -> int:
+    if isinstance(value, int):
+        return value
+    lowered = str(value).strip().lower()
+    mapping = {"high": 1, "medium": 2, "low": 3}
+    return mapping.get(lowered, 2)

--- a/tests/integration/test_routes.py
+++ b/tests/integration/test_routes.py
@@ -8,3 +8,9 @@ def test_routes_exist() -> None:
     assert client.get("/v1/status/agent-runs/failures").status_code == 200
     assert client.get("/v1/actions").status_code == 200
     assert client.get("/v1/drafts").status_code == 200
+    response = client.post(
+        "/v1/study/ingest",
+        json={"source_type": "manual", "raw_text": "Gap: weak in graph DP\nTODO: solve 3 problems"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "accepted"

--- a/tests/unit/test_study_agent.py
+++ b/tests/unit/test_study_agent.py
@@ -1,0 +1,17 @@
+from helm_agents.study_agent import extract_study_artifacts
+
+
+def test_extract_study_artifacts_detects_tasks_and_gaps() -> None:
+    raw_text = """
+    System design prep for distributed caches.
+    Gap: I am confused about consistent hashing rebalancing.
+    TODO: Practice two cache invalidation examples today.
+    """
+
+    artifacts = extract_study_artifacts(raw_text)
+
+    assert artifacts["summary"]
+    assert len(artifacts["knowledge_gaps"]) == 1
+    assert artifacts["knowledge_gaps"][0]["severity"] == "medium"
+    assert len(artifacts["learning_tasks"]) == 1
+    assert artifacts["learning_tasks"][0]["priority"] == 1

--- a/tests/unit/test_study_ingest_repository.py
+++ b/tests/unit/test_study_ingest_repository.py
@@ -1,0 +1,43 @@
+from helm_storage.db import Base
+from helm_storage.models import KnowledgeGapORM, LearningTaskORM, StudySessionORM
+from helm_storage.repositories.study_ingest import SQLAlchemyStudyIngestRepository
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+
+def test_create_session_with_artifacts_persists_linked_records() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as session:
+        repository = SQLAlchemyStudyIngestRepository(session)
+        study_session = repository.create_session_with_artifacts(
+            source_type="manual",
+            raw_text="Gap: weak in dijkstra\nTODO: practice dijkstra",
+            summary="Practiced graph algorithms.",
+            knowledge_gaps=[
+                {"topic": "dijkstra", "description": "weak in dijkstra", "severity": "medium"}
+            ],
+            learning_tasks=[
+                {
+                    "title": "practice dijkstra",
+                    "description": "solve 5 dijkstra problems",
+                    "priority": 2,
+                    "status": "open",
+                    "related_gap_index": 0,
+                }
+            ],
+        )
+
+        persisted_session = session.execute(
+            select(StudySessionORM).where(StudySessionORM.id == study_session.id)
+        ).scalar_one()
+        persisted_gap = session.execute(
+            select(KnowledgeGapORM).where(KnowledgeGapORM.source_session_id == study_session.id)
+        ).scalar_one()
+        persisted_task = session.execute(select(LearningTaskORM)).scalar_one()
+
+    assert persisted_session.summary == "Practiced graph algorithms."
+    assert persisted_gap.topic == "dijkstra"
+    assert persisted_task.related_gap_id == persisted_gap.id


### PR DESCRIPTION
## Summary
- wire manual study ingest endpoint to artifact extraction + storage persistence
- add study extraction helper and study ingest repository scaffolding
- return study ingest response metadata (summary/task/gap counts + persistence info)
- add unit/integration tests for study agent and ingest repository

## Linked Work
- Linked Linear: RHE-19

## Validation
- bash scripts/lint.sh
- bash scripts/test.sh
